### PR TITLE
Add privacy page and load album art from MP3 metadata

### DIFF
--- a/music.html
+++ b/music.html
@@ -13,13 +13,14 @@
             <h1>chase</h1>
             <p class="subtitle">developer • creator • human</p>
             <nav>
-                <ul>
-                    <li><a href="index.html" class="nav-link">about</a></li>
-                    <li><a href="music.html" class="nav-link active">music</a></li>
-                    <li><a href="work.html" class="nav-link">work</a></li>
-                </ul>
-            </nav>
-        </header>
+                    <ul>
+                        <li><a href="index.html" class="nav-link">about</a></li>
+                        <li><a href="music.html" class="nav-link active">music</a></li>
+                        <li><a href="work.html" class="nav-link">work</a></li>
+                        <li><a href="privacy.html" class="nav-link">privacy</a></li>
+                    </ul>
+                </nav>
+            </header>
         <main>
             <section id="music">
                 <h2>$ now_playing</h2>
@@ -55,6 +56,7 @@
             </section>
         </main>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Chase Marshall</title>
+    <title>Chase Marshall - Privacy</title>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 </head>
@@ -13,30 +13,28 @@
             <h1>chase</h1>
             <p class="subtitle">developer • creator • human</p>
             <nav>
-                    <ul>
-                        <li><a href="index.html" class="nav-link active">about</a></li>
-                        <li><a href="music.html" class="nav-link">music</a></li>
-                        <li><a href="work.html" class="nav-link">work</a></li>
-                        <li><a href="privacy.html" class="nav-link">privacy</a></li>
-                    </ul>
-                </nav>
-            </header>
+                <ul>
+                    <li><a href="index.html" class="nav-link">about</a></li>
+                    <li><a href="music.html" class="nav-link">music</a></li>
+                    <li><a href="work.html" class="nav-link">work</a></li>
+                    <li><a href="privacy.html" class="nav-link active">privacy</a></li>
+                </ul>
+            </nav>
+        </header>
         <main>
-            <section id="about">
-                <h2>$ whoami</h2>
+            <section id="privacy">
+                <h2>$ privacy_matters</h2>
+                <blockquote>
+                    "Privacy is not something that I'm merely entitled to, it's an absolute prerequisite." – Marlon Brando
+                </blockquote>
                 <p>
-                    hey there! i'm a developer who loves building things that matter.
-                    currently focused on creating elegant solutions to complex problems.
+                    in a world where everything is tracked, caring about your privacy is an act of self-defense.
+                    take the time to learn how your data is used and how you can protect it.
                 </p>
-                <p>
-                    when i'm not coding, you'll find me exploring new music, diving into
-                    design systems, or probably overthinking the perfect font pairing
-                    (spoiler: it's usually jetbrains mono).
-                </p>
-                <p>
-                    i believe in clean code, minimalist design, and the power of
-                    good typography to make everything better.
-                </p>
+                <ul>
+                    <li><a href="https://privacyactivistkit.org/" target="_blank" rel="noopener noreferrer">Privacy Activist Kit</a></li>
+                    <li><a href="https://www.privacyguides.org/en/" target="_blank" rel="noopener noreferrer">Privacy Guides</a></li>
+                </ul>
             </section>
         </main>
     </div>

--- a/work.html
+++ b/work.html
@@ -13,13 +13,14 @@
             <h1>chase</h1>
             <p class="subtitle">developer • creator • human</p>
             <nav>
-                <ul>
-                    <li><a href="index.html" class="nav-link">about</a></li>
-                    <li><a href="music.html" class="nav-link">music</a></li>
-                    <li><a href="work.html" class="nav-link active">work</a></li>
-                </ul>
-            </nav>
-        </header>
+                    <ul>
+                        <li><a href="index.html" class="nav-link">about</a></li>
+                        <li><a href="music.html" class="nav-link">music</a></li>
+                        <li><a href="work.html" class="nav-link active">work</a></li>
+                        <li><a href="privacy.html" class="nav-link">privacy</a></li>
+                    </ul>
+                </nav>
+            </header>
         <main>
             <section id="work">
                 <h2>$ ls projects/</h2>
@@ -64,6 +65,7 @@
         <div class="floating-text" id="floatingText">loading...</div>
     </div>
     <audio id="audioPlayer" preload="auto" style="display:none"></audio>
+    <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Parse MP3 files with music-metadata-browser to show embedded album art
- Add new Privacy page with quote and resource links
- Update navigation and include metadata library across pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eeca4f73c832090fd98502f0d7903