### PR TITLE
Enable autoplay music and redesign privacy badges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -417,6 +417,8 @@
             color: var(--text);
             margin-bottom: 0.5rem;
             font-size: 1.1rem;
+            display: flex;
+            align-items: center;
         }
 
         .project-desc,
@@ -440,7 +442,12 @@
             font-family: 'JetBrains Mono', 'Courier New', monospace;
             padding: 0.2rem 0.4rem;
             border-radius: 4px;
-            margin-left: 0.5rem;
+        }
+
+        .badges {
+            margin-left: auto;
+            display: flex;
+            gap: 0.3rem;
         }
 
         .highlight {

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         </div>
         <div class="floating-text" id="floatingText">loading...</div>
     </div>
-    <audio id="audioPlayer" preload="auto" style="display:none"></audio>
+    <audio id="audioPlayer" preload="auto" style="display:none" autoplay></audio>
     <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -230,9 +230,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         }
         audioPlayer.addEventListener('canplay', function () {
             audioPlayer.currentTime = initialState.time || 0;
-            if (initialState.isPlaying !== false) {
-                playTrack();
-            }
+            playTrack();
         }, { once: true });
     }
     const title = document.querySelector('h1');

--- a/music.html
+++ b/music.html
@@ -49,7 +49,7 @@
                         <input type="range" id="volumeSlider" class="volume-slider" min="0" max="1" step="0.01" value="1">
                     </div>
                 </div>
-                <audio id="audioPlayer" preload="auto"></audio>
+                <audio id="audioPlayer" preload="auto" autoplay></audio>
                 <p id="musicDescription">
                     my favorite tracks - click play or use arrows to explore
                 </p>

--- a/privacy.html
+++ b/privacy.html
@@ -24,20 +24,17 @@
         <main>
             <section id="privacy">
                 <h2>$ privacy_matters</h2>
-                <blockquote>
-                    "Privacy is not something that I'm merely entitled to, it's an absolute prerequisite." – Marlon Brando
-                </blockquote>
                 <p>
                     In the modern age of digital data exploitation, your privacy has never been more critical, and yet many believe it is already a lost cause. It is not. <span class="highlight">Your privacy is up for grabs</span>, and you need to care about it. Privacy is about power, and it is so important that this power ends up in the right hands.
                 </p>
                 <div class="resource" onclick="window.open('https://www.privacyguides.org/en/', '_blank')">
-                    <h3>Privacy Guides</h3>
+                    <h3>The Privacy Guides <span class="badges"><span class="badge">🛡️</span><span class="badge">🔥</span></span></h3>
                     <p class="resource-desc">
                         Privacy Guides is a not-for-profit, volunteer-run project that hosts online communities and publishes news and recommendations surrounding privacy and security tools, services, and knowledge.
                     </p>
                 </div>
                 <div class="resource" onclick="window.open('https://privacyactivistkit.org/', '_blank')">
-                    <h3>Privacy Activist Kit <span class="badge">beginner friendly</span></h3>
+                    <h3>Privacy Activist Kit <span class="badges"><span class="badge">🛡️</span><span class="badge">🌱</span></span></h3>
                     <p class="resource-desc">
                         The Privacy Activist Kit is a free, open source hub of privacy tools, guides, teaching materials, and simple explanations designed to support activists, organizers, educators, students, curious beginners, and anyone tired of being tracked online.
                     </p>
@@ -54,7 +51,7 @@
         </div>
         <div class="floating-text" id="floatingText">loading...</div>
     </div>
-    <audio id="audioPlayer" preload="auto" style="display:none"></audio>
+    <audio id="audioPlayer" preload="auto" style="display:none" autoplay></audio>
     <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/work.html
+++ b/work.html
@@ -64,7 +64,7 @@
         </div>
         <div class="floating-text" id="floatingText">loading...</div>
     </div>
-    <audio id="audioPlayer" preload="auto" style="display:none"></audio>
+    <audio id="audioPlayer" preload="auto" style="display:none" autoplay></audio>
     <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Autoplay music immediately on page load and simplify audio player initialization.
- Remove quote from privacy page and rename first resource to "The Privacy Guides".
- Replace text badges with icon-based shields/difficulty indicators, aligned to the right of each resource.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ef5315bf0832080d495b6c2c0ed6c