### PR TITLE
Improve privacy page link and badge styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -448,10 +448,33 @@
             justify-content: center;
             cursor: pointer;
             transition: background 0.2s ease;
+            position: relative;
         }
 
         .badge:hover {
             background: var(--text);
+        }
+
+        .badge::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            bottom: 130%;
+            left: 50%;
+            transform: translateX(-50%);
+            background: var(--hover);
+            color: var(--text);
+            padding: 0.25rem 0.5rem;
+            border-radius: 4px;
+            white-space: nowrap;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 0.75rem;
+        }
+
+        .badge:hover::after {
+            opacity: 1;
         }
 
         .badges {
@@ -462,6 +485,15 @@
 
         .highlight {
             color: var(--accent);
+        }
+
+        .inline-link {
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        .inline-link:hover {
+            text-decoration: underline;
         }
 
         /* Responsive */

--- a/privacy.html
+++ b/privacy.html
@@ -25,16 +25,16 @@
             <section id="privacy">
                 <h2>$ privacy_matters</h2>
                 <p>
-                    In the modern age of digital data exploitation, your privacy has never been more critical, and yet many believe it is already a lost cause. It is not. <span class="highlight">Your privacy is up for grabs</span>, and you need to care about it. Privacy is about power, and it is so important that this power ends up in the right hands. - The Privacy Guide<sup><a href="https://www.privacyguides.org/en/" target="_blank">1</a></sup>
+                    In the modern age of digital data exploitation, your privacy has never been more critical, and yet many believe it is already a lost cause. It is not. <span class="highlight">Your privacy is up for grabs</span>, and you need to care about it. Privacy is about power, and it is so important that this power ends up in the right hands. - <a href="https://www.privacyguides.org/en/" target="_blank" class="inline-link">The Privacy Guide</a>
                 </p>
                 <div class="resource" onclick="window.open('https://www.privacyguides.org/en/', '_blank')">
-                    <h3>The Privacy Guides <span class="badges"><span class="badge" title="Security resource">🛡️</span><span class="badge difficulty" title="Difficulty: Hard">H</span></span></h3>
+                    <h3>The Privacy Guides <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Intermediate">⭐</span></span></h3>
                     <p class="resource-desc">
                         Privacy Guides is a not-for-profit, volunteer-run project that hosts online communities and publishes news and recommendations surrounding privacy and security tools, services, and knowledge.
                     </p>
                 </div>
                 <div class="resource" onclick="window.open('https://privacyactivistkit.org/', '_blank')">
-                    <h3>Privacy Activist Kit <span class="badges"><span class="badge" title="Security resource">🛡️</span><span class="badge difficulty" title="Difficulty: Easy">E</span></span></h3>
+                    <h3>Privacy Activist Kit <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Beginner">🌱</span></span></h3>
                     <p class="resource-desc">
                         The Privacy Activist Kit is a free, open source hub of privacy tools, guides, teaching materials, and simple explanations designed to support activists, organizers, educators, students, curious beginners, and anyone tired of being tracked online.
                     </p>


### PR DESCRIPTION
## Summary
- Replace privacy page footnote with inline link styled to match site theme.
- Revamp resource badges with circular emoji icons and custom tooltips for user-friendly levels.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688ef9f83fb483208e29d2383d40c717