### PR TITLE
Add privacy quiz and theme toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,14 @@
             --hover: #1a1a1a;
         }
 
+        body.light-mode {
+            --bg: #fafafa;
+            --text: #1a1a1a;
+            --text-dim: #555555;
+            --border: #d4d4d4;
+            --hover: #e5e5e5;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -20,6 +28,7 @@
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             line-height: 1.6;
             overflow-x: hidden;
+            transition: background 0.3s ease, color 0.3s ease;
         }
 
         .container {
@@ -494,6 +503,104 @@
 
         .inline-link:hover {
             text-decoration: underline;
+        }
+
+        .theme-toggle {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            cursor: pointer;
+            font-size: 1.5rem;
+            color: var(--text);
+            transition: transform 0.3s ease;
+            z-index: 1000;
+        }
+
+        .theme-toggle:hover {
+            transform: scale(1.1);
+        }
+
+        .tab-container {
+            margin: 2rem 0;
+            display: flex;
+            gap: 1rem;
+        }
+
+        .tab {
+            background: var(--hover);
+            color: var(--text);
+            border: 1px solid var(--border);
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            cursor: pointer;
+            font-family: 'JetBrains Mono', 'Courier New', monospace;
+            transition: background 0.3s ease;
+        }
+
+        .tab.active {
+            background: var(--accent);
+            color: var(--bg);
+        }
+
+        .quiz-card {
+            border: 1px solid var(--border);
+            background: var(--hover);
+            padding: 1.5rem;
+            border-radius: 8px;
+            margin-top: 1rem;
+            font-family: 'JetBrains Mono', 'Courier New', monospace;
+        }
+
+        .quiz-option {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin: 0.5rem 0;
+            cursor: pointer;
+        }
+
+        .submit-btn {
+            margin-top: 1rem;
+            background: var(--accent);
+            color: var(--bg);
+            border: none;
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            cursor: pointer;
+            font-family: 'JetBrains Mono', 'Courier New', monospace;
+        }
+
+        .feedback {
+            margin-top: 1rem;
+        }
+
+        .feedback.correct {
+            color: #16a34a;
+        }
+
+        .feedback.incorrect {
+            color: #dc2626;
+        }
+
+        .quiz-links {
+            margin-top: 1rem;
+            list-style: disc;
+            padding-left: 1.5rem;
+        }
+
+        .fade-in {
+            animation: fade 0.3s ease;
+        }
+
+        @keyframes fade {
+            from {
+                opacity: 0;
+                transform: translateY(10px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
         }
 
         /* Responsive */

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+    <div id="themeToggle" class="theme-toggle">☀️</div>
     <div class="container">
         <header>
             <h1>chase</h1>

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,18 @@ let isPlaying = false;
 const audioPlayer = document.getElementById('audioPlayer');
 let initialState = {};
 
+function applyTheme(mode) {
+    document.body.classList.toggle('light-mode', mode === 'light');
+    const toggle = document.getElementById('themeToggle');
+    if (toggle) toggle.textContent = mode === 'light' ? '🌙' : '☀️';
+    localStorage.setItem('theme', mode);
+}
+
+function toggleTheme() {
+    const current = localStorage.getItem('theme') || 'dark';
+    applyTheme(current === 'dark' ? 'light' : 'dark');
+}
+
 function arrayBufferToBase64(buffer) {
     let binary = '';
     const bytes = new Uint8Array(buffer);
@@ -217,6 +229,12 @@ function openProject(projectId) {
 
 // Initialize
 document.addEventListener('DOMContentLoaded', async function () {
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    applyTheme(savedTheme);
+    const themeToggle = document.getElementById('themeToggle');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', toggleTheme);
+    }
     await loadPlaylist();
     restoreState();
     showTrack(currentTrack);

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,0 +1,126 @@
+const quizData = [
+    {
+        question: "Which is a secure way to manage passwords?",
+        options: [
+            "Use the same password everywhere",
+            "Use a password manager",
+            "Write them on sticky notes"
+        ],
+        answer: 1,
+        feedback: "Password managers generate and store unique passwords for every site."
+    },
+    {
+        question: "What does HTTPS provide?",
+        options: [
+            "It speeds up your internet",
+            "Encrypted communication between you and the website",
+            "Better search results"
+        ],
+        answer: 1,
+        feedback: "HTTPS encrypts data, protecting it from eavesdroppers."
+    },
+    {
+        question: "Which of the following reduces online tracking?",
+        options: [
+            "Accepting all cookies",
+            "Using private browsing and tracker blockers",
+            "Sharing your location with every website"
+        ],
+        answer: 1,
+        feedback: "Private browsing and tracker blockers limit the data companies can collect."
+    }
+];
+
+let currentQuestion = 0;
+let score = 0;
+
+function showQuestion() {
+    const q = quizData[currentQuestion];
+    const container = document.getElementById('quizContent');
+    container.innerHTML = `
+        <div class="quiz-card fade-in">
+            <h3>${q.question}</h3>
+            <form id="quizForm">
+                ${q.options.map((opt, idx) => `
+                    <label class="quiz-option">
+                        <input type="radio" name="option" value="${idx}">
+                        <span>${opt}</span>
+                    </label>
+                `).join('')}
+                <button type="submit" class="submit-btn">submit</button>
+            </form>
+            <div id="feedback" class="feedback"></div>
+        </div>`;
+    document.getElementById('quizForm').addEventListener('submit', handleSubmit);
+}
+
+function handleSubmit(e) {
+    e.preventDefault();
+    const selected = document.querySelector('input[name="option"]:checked');
+    if (!selected) return;
+    const idx = parseInt(selected.value);
+    const q = quizData[currentQuestion];
+    const feedback = document.getElementById('feedback');
+    if (idx === q.answer) {
+        feedback.textContent = 'Correct! ' + q.feedback;
+        feedback.className = 'feedback correct';
+        score++;
+    } else {
+        feedback.textContent = 'Incorrect. ' + q.feedback;
+        feedback.className = 'feedback incorrect';
+    }
+    document.querySelector('.submit-btn').disabled = true;
+    setTimeout(() => {
+        currentQuestion++;
+        if (currentQuestion < quizData.length) {
+            showQuestion();
+        } else {
+            showResults();
+        }
+    }, 1000);
+}
+
+function showResults() {
+    const container = document.getElementById('quizContent');
+    const percent = Math.round((score / quizData.length) * 100);
+    container.innerHTML = `
+        <div class="quiz-card fade-in">
+            <h3>Your privacy score: ${score}/${quizData.length}</h3>
+            <p>${getMessage(percent)}</p>
+            <p>Further reading:</p>
+            <ul class="quiz-links">
+                <li><a href="https://www.privacyguides.org/en/" target="_blank" class="inline-link">Privacy Guides</a></li>
+                <li><a href="https://privacyactivistkit.org/" target="_blank" class="inline-link">Privacy Activist Kit</a></li>
+            </ul>
+        </div>`;
+}
+
+function getMessage(percent) {
+    if (percent === 100) return 'Excellent! You\'re a privacy pro.';
+    if (percent >= 60) return 'Good job! There\'s always more to learn.';
+    return 'Consider exploring the resources below to improve your privacy.';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const quizTab = document.getElementById('quizTab');
+    const resourcesTab = document.getElementById('resourcesTab');
+    const quizSection = document.getElementById('quizSection');
+    const resourcesSection = document.getElementById('resourcesSection');
+
+    if (quizTab && resourcesTab) {
+        quizTab.addEventListener('click', () => {
+            quizTab.classList.add('active');
+            resourcesTab.classList.remove('active');
+            resourcesSection.style.display = 'none';
+            quizSection.style.display = 'block';
+            showQuestion();
+        });
+
+        resourcesTab.addEventListener('click', () => {
+            resourcesTab.classList.add('active');
+            quizTab.classList.remove('active');
+            quizSection.style.display = 'none';
+            resourcesSection.style.display = 'block';
+        });
+    }
+});

--- a/music.html
+++ b/music.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+    <div id="themeToggle" class="theme-toggle">☀️</div>
     <div class="container">
         <header>
             <h1>chase</h1>

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+    <div id="themeToggle" class="theme-toggle">☀️</div>
     <div class="container">
         <header>
             <h1>chase</h1>
@@ -24,20 +25,29 @@
         <main>
             <section id="privacy">
                 <h2>$ privacy_matters</h2>
-                <p>
-                    In the modern age of digital data exploitation, your privacy has never been more critical, and yet many believe it is already a lost cause. It is not. <span class="highlight">Your privacy is up for grabs</span>, and you need to care about it. Privacy is about power, and it is so important that this power ends up in the right hands. - <a href="https://www.privacyguides.org/en/" target="_blank" class="inline-link">The Privacy Guide</a>
-                </p>
-                <div class="resource" onclick="window.open('https://www.privacyguides.org/en/', '_blank')">
-                    <h3>The Privacy Guides <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Intermediate">⭐</span></span></h3>
-                    <p class="resource-desc">
-                        Privacy Guides is a not-for-profit, volunteer-run project that hosts online communities and publishes news and recommendations surrounding privacy and security tools, services, and knowledge.
-                    </p>
+                <div class="tab-container">
+                    <button id="resourcesTab" class="tab active">resources</button>
+                    <button id="quizTab" class="tab">quiz</button>
                 </div>
-                <div class="resource" onclick="window.open('https://privacyactivistkit.org/', '_blank')">
-                    <h3>Privacy Activist Kit <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Beginner">🌱</span></span></h3>
-                    <p class="resource-desc">
-                        The Privacy Activist Kit is a free, open source hub of privacy tools, guides, teaching materials, and simple explanations designed to support activists, organizers, educators, students, curious beginners, and anyone tired of being tracked online.
+                <div id="resourcesSection" class="fade-in">
+                    <p>
+                        In the modern age of digital data exploitation, your privacy has never been more critical, and yet many believe it is already a lost cause. It is not. <span class="highlight">Your privacy is up for grabs</span>, and you need to care about it. Privacy is about power, and it is so important that this power ends up in the right hands. - <a href="https://www.privacyguides.org/en/" target="_blank" class="inline-link">The Privacy Guide</a>
                     </p>
+                    <div class="resource" onclick="window.open('https://www.privacyguides.org/en/', '_blank')">
+                        <h3>The Privacy Guides <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Intermediate">⭐</span></span></h3>
+                        <p class="resource-desc">
+                            Privacy Guides is a not-for-profit, volunteer-run project that hosts online communities and publishes news and recommendations surrounding privacy and security tools, services, and knowledge.
+                        </p>
+                    </div>
+                    <div class="resource" onclick="window.open('https://privacyactivistkit.org/', '_blank')">
+                        <h3>Privacy Activist Kit <span class="badges"><span class="badge" data-tooltip="Security resource">🔒</span><span class="badge" data-tooltip="Level: Beginner">🌱</span></span></h3>
+                        <p class="resource-desc">
+                            The Privacy Activist Kit is a free, open source hub of privacy tools, guides, teaching materials, and simple explanations designed to support activists, organizers, educators, students, curious beginners, and anyone tired of being tracked online.
+                        </p>
+                    </div>
+                </div>
+                <div id="quizSection" style="display:none;">
+                    <div id="quizContent"></div>
                 </div>
             </section>
         </main>
@@ -54,5 +64,6 @@
     <audio id="audioPlayer" preload="auto" style="display:none" autoplay></audio>
     <script src="https://cdn.jsdelivr.net/npm/music-metadata-browser/dist/music-metadata-browser.min.js"></script>
     <script src="js/main.js"></script>
+    <script src="js/quiz.js"></script>
 </body>
 </html>

--- a/work.html
+++ b/work.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+    <div id="themeToggle" class="theme-toggle">☀️</div>
     <div class="container">
         <header>
             <h1>chase</h1>


### PR DESCRIPTION
## Summary
- add terminal-inspired privacy quiz with instant feedback, score, and resources
- introduce light/dark theme toggle saved in localStorage across pages

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688efd5857808320ad73c67442cf8954