### PR TITLE
Add privacy-redirector project tile

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -222,7 +222,8 @@ function openProject(projectId) {
         'project1': 'https://github.com/chasemarshall/python-password-manager',
         'project2': 'https://github.com/chasemarshall/dotfiles',
         'project3': 'https://github.com/chasemarshall/ticket-system',
-        'project4': 'https://github.com/chasemarshall/trash-pickup'
+        'project4': 'https://github.com/chasemarshall/trash-pickup',
+        'project5': 'https://github.com/chasemarshall/privacy-redirector'
     };
     window.open(projectUrls[projectId], '_blank');
 }

--- a/work.html
+++ b/work.html
@@ -54,6 +54,13 @@
                     </p>
                     <p class="project-tech">javascript • pwa</p>
                 </div>
+                <div class="project" onclick="openProject('project5')">
+                    <h3>privacy-redirector</h3>
+                    <p class="project-desc">
+                        A Firefox extension that automatically redirects YouTube to Piped and Reddit to custom privacy-friendly instances, while completely blocking data transmission to Google/YouTube servers.
+                    </p>
+                    <p class="project-tech">javascript • html</p>
+                </div>
             </section>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- feature: add privacy-redirector to work page
- chore: wire up privacy-redirector link in project handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fb6ef43548320950429e5e5c7c8e3